### PR TITLE
Ensure onNewIntent() passes NEW intent extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Gets called when onNewIntent is called for the parent activity. Used in only cer
         }
     });
 
+
 ### sendBroadcast ###
 Sends a custom intent passing optional extras
 
@@ -97,6 +98,17 @@ Sends a custom intent passing optional extras
             }, function() {
             }, function() {
     });
+
+### removeExtra ###
+Removes the specified extra
+
+	window.plugins.webintent.removeExtra(window.plugins.webintent.EXTRA_TEXT,
+        function() {
+            // Extra was removed
+        }, function() {
+            // Something really bad happened.
+        }
+    );
 
 ## Licence ##
 

--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -175,6 +175,9 @@ public class WebIntent extends CordovaPlugin {
     @Override
     public void onNewIntent(Intent intent) {
 
+        super.onNewIntent(intent);
+        ((CordovaActivity)this.cordova.getActivity()).setIntent(intent);
+
         if (this.onNewIntentCallbackContext != null) {
             PluginResult result = new PluginResult(PluginResult.Status.OK, intent.getDataString());
             result.setKeepCallback(true);

--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -45,7 +45,7 @@ public class WebIntent extends CordovaPlugin {
                 }
 
                 // Parse the arguments
-				final CordovaResourceApi resourceApi = webView.getResourceApi();
+                final CordovaResourceApi resourceApi = webView.getResourceApi();
                 JSONObject obj = args.getJSONObject(0);
                 String type = obj.has("type") ? obj.getString("type") : null;
                 Uri uri = obj.has("url") ? resourceApi.remapUri(Uri.parse(obj.getString("url"))) : null;
@@ -109,14 +109,14 @@ public class WebIntent extends CordovaPlugin {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, uri));
                 return true;
             } else if (action.equals("onNewIntent")) {
-            	//save reference to the callback; will be called on "new intent" events
+                //save reference to the callback; will be called on "new intent" events
                 this.onNewIntentCallbackContext = callbackContext;
-        
+
                 if (args.length() != 0) {
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
-                
+
                 PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
                 result.setKeepCallback(true); //re-use the callback on intent events
                 callbackContext.sendPluginResult(result);
@@ -165,17 +165,17 @@ public class WebIntent extends CordovaPlugin {
 
     @Override
     public void onNewIntent(Intent intent) {
-    	 
+
         if (this.onNewIntentCallbackContext != null) {
-        	PluginResult result = new PluginResult(PluginResult.Status.OK, intent.getDataString());
-        	result.setKeepCallback(true);
+            PluginResult result = new PluginResult(PluginResult.Status.OK, intent.getDataString());
+            result.setKeepCallback(true);
             this.onNewIntentCallbackContext.sendPluginResult(result);
         }
     }
 
     void startActivity(String action, Uri uri, String type, Map<String, String> extras) {
         Intent i = (uri != null ? new Intent(action, uri) : new Intent(action));
-        
+
         if (type != null && uri != null) {
             i.setDataAndType(uri, type); //Fix the crash problem with android 2.3.6
         } else {
@@ -183,7 +183,7 @@ public class WebIntent extends CordovaPlugin {
                 i.setType(type);
             }
         }
-        
+
         for (String key : extras.keySet()) {
             String value = extras.get(key);
             // If type is text html, the extra text must sent as HTML
@@ -192,7 +192,7 @@ public class WebIntent extends CordovaPlugin {
             } else if (key.equals(Intent.EXTRA_STREAM)) {
                 // allowes sharing of images as attachments.
                 // value in this case should be a URI of a file
-				final CordovaResourceApi resourceApi = webView.getResourceApi();
+                final CordovaResourceApi resourceApi = webView.getResourceApi();
                 i.putExtra(key, resourceApi.remapUri(Uri.parse(value)));
             } else if (key.equals(Intent.EXTRA_EMAIL)) {
                 // allows to add the email address of the receiver

--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -122,8 +122,7 @@ public class WebIntent extends CordovaPlugin {
                 callbackContext.sendPluginResult(result);
                 return true;
                 //return result;
-            } else if (action.equals("sendBroadcast")) 
-            {
+            } else if (action.equals("sendBroadcast")) {
                 if (args.length() != 1) {
                     //return new PluginResult(PluginResult.Status.INVALID_ACTION);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
@@ -150,7 +149,17 @@ public class WebIntent extends CordovaPlugin {
                 //return new PluginResult(PluginResult.Status.OK);
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
                 return true;
+            } else if (action.equals("removeExtra")) {
+                if (args.length() != 1) {
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
+                    return false;
+                }
+                Intent i = ((CordovaActivity)this.cordova.getActivity()).getIntent();
+                String extraName = args.getString(0);
+                i.removeExtra(extraName);
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
             }
+
             //return new PluginResult(PluginResult.Status.INVALID_ACTION);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
             return false;

--- a/www/webintent.js
+++ b/www/webintent.js
@@ -65,6 +65,14 @@
         }, 'WebIntent', 'sendBroadcast', [params]);
     };
 
+    WebIntent.prototype.removeExtra = function(params, success, fail) {
+        return cordova.exec(function(args) {
+            success(args);
+        }, function(args) {
+            fail(args);
+        }, 'WebIntent', 'removeExtra', [params]);
+    };
+
     window.webintent = new WebIntent();
 
     // backwards compatibility

--- a/www/webintent.js
+++ b/www/webintent.js
@@ -66,7 +66,7 @@
     };
 
     window.webintent = new WebIntent();
-    
+
     // backwards compatibility
     window.plugins = window.plugins || {};
     window.plugins.webintent = window.webintent;


### PR DESCRIPTION
There is no way to mark an Intent as resolved / consumed.

If the user tries to send/view to the same app multiple times in a row without force
quitting the app in between, the same EXTRAs will be returned.

To work around this, update the Activity's intent for each new intent.
