### PR TITLE
Load this plugin on startup

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -16,6 +16,7 @@
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="WebIntent" >
                 <param name="android-package" value="com.borismus.webintent.WebIntent"/>
+                <param name="onload" value="true" />
             </feature>
         </config-file>
 


### PR DESCRIPTION
The Problem:
1/ Your activity has launchMode = SingleTask
2/ User puts activity into background and is then later destroyed.
3/ User selects your activity with a new intent.
4/ Your activity is restarted and onNewIntent is immediately called.
5/ The webintent plugin fails to capture this critical event as it has not yet started.

The Solution:
Add onload = true to the plugin.xml file so that the plugin is loaded immediately and can therefore capture the onNewIntent event.
